### PR TITLE
[BassClarinetTest FIX] Javac requires the filename to match the class name

### DIFF
--- a/Lab00App-build/Lab00App-tests/src/test/java/ch/heigvd/res/lab00/BassClarinetTest.java
+++ b/Lab00App-build/Lab00App-tests/src/test/java/ch/heigvd/res/lab00/BassClarinetTest.java
@@ -1,4 +1,3 @@
-
 package ch.heigvd.res.lab00;
 
 import org.junit.Assert;


### PR DESCRIPTION
Sorry about that, wasn't paying attention.